### PR TITLE
Add screen and touch pad rotation.

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -2171,6 +2171,8 @@
 // FSMC display (MKS Robin, Alfawise U20, JGAurora A5S, REXYZ A1, etc.)
 //
 #define FSMC_GRAPHICAL_TFT
+// Define for FLSUN Q5. Comment for qq-s
+#define TFT_SCREEN_ROTATE_180
 
 //=============================================================================
 //============================  Other Controllers  ============================
@@ -2188,6 +2190,9 @@
   #define XPT2046_Y_CALIBRATION  -8981
   #define XPT2046_X_OFFSET       -43
   #define XPT2046_Y_OFFSET        257
+
+  // Rotate screen for FLSUN Q5
+  #define XPT2046_ROTATE_180
 #endif
 
 //

--- a/Marlin/src/feature/touch/xpt2046.cpp
+++ b/Marlin/src/feature/touch/xpt2046.cpp
@@ -40,6 +40,9 @@
   #define TOUCH_CS_PIN   CS_PIN
 #endif
 
+#define TOUCH_MAX_X 320
+#define TOUCH_MAX_Y 240
+
 XPT2046 touch;
 extern int8_t encoderDiff;
 
@@ -74,9 +77,14 @@ uint8_t XPT2046::read_buttons() {
   // We rely on XPT2046 compatible mode to ADS7843, hence no Z1 and Z2 measurements possible.
 
   if (!isTouched()) return 0;
-  const uint16_t x = uint16_t(((uint32_t(getInTouch(XPT2046_X))) * tsoffsets[0]) >> 16) + tsoffsets[1],
+  uint16_t x = uint16_t(((uint32_t(getInTouch(XPT2046_X))) * tsoffsets[0]) >> 16) + tsoffsets[1],
                  y = uint16_t(((uint32_t(getInTouch(XPT2046_Y))) * tsoffsets[2]) >> 16) + tsoffsets[3];
   if (!isTouched()) return 0; // Fingers must still be on the TS for a valid read.
+
+  #ifdef XPT2046_ROTATE_180
+        x = TOUCH_MAX_X - x;
+        y = TOUCH_MAX_Y - y;
+  #endif
 
   if (y < 175 || y > 234) return 0;
 

--- a/Marlin/src/lcd/dogm/u8g_dev_tft_320x240_upscale_from_128x64.cpp
+++ b/Marlin/src/lcd/dogm/u8g_dev_tft_320x240_upscale_from_128x64.cpp
@@ -294,11 +294,17 @@ void (*setWindow)(u8g_t *u8g, u8g_dev_t *dev, uint16_t Xmin, uint16_t Ymin, uint
   }
 #endif
 
+#ifndef TFT_SCREEN_ROTATE_180
+    #define ST7789V_INIT_SCREEN_WORD 0x00A0
+#else
+  #define ST7789V_INIT_SCREEN_WORD 0x0060
+#endif
+
 static const uint16_t st7789v_init[] = {
   ESC_REG(0x0010), ESC_DELAY(10),
   ESC_REG(0x0001), ESC_DELAY(200),
   ESC_REG(0x0011), ESC_DELAY(120),
-  ESC_REG(0x0036), 0x00A0,
+  ESC_REG(0x0036), ST7789V_INIT_SCREEN_WORD,
   ESC_REG(0x003A), 0x0055,
   ESC_REG(0x002A), 0x0000, 0x0000, 0x0001, 0x003F,
   ESC_REG(0x002B), 0x0000, 0x0000, 0x0000, 0x00EF,


### PR DESCRIPTION
Add future for rotate screen for ST7789v TFT, and touch pad XPT2046. Its nees for FLSUN Q5 printer.
Control rotation from add:
#define TFT_SCREEN_ROTATE_180
#define XPT2046_ROTATE_180
in Configuraton.h file